### PR TITLE
remove ambient sounds and enviromental effects from more maps + Improve formatting

### DIFF
--- a/maps/createfx/mp_bloc_sh_fx.gsc
+++ b/maps/createfx/mp_bloc_sh_fx.gsc
@@ -1,0 +1,2 @@
+//_createfx generated. Do not touch!!
+main(){}

--- a/maps/createfx/mp_cargoship_sh_fx.gsc
+++ b/maps/createfx/mp_cargoship_sh_fx.gsc
@@ -1,0 +1,2 @@
+//_createfx generated. Do not touch!!
+main(){}

--- a/maps/createfx/mp_estate_tropical_fx.gsc
+++ b/maps/createfx/mp_estate_tropical_fx.gsc
@@ -1,0 +1,2 @@
+//_createfx generated. Do not touch!!
+main(){}

--- a/maps/createfx/mp_firingrange_fx.gsc
+++ b/maps/createfx/mp_firingrange_fx.gsc
@@ -1,0 +1,2 @@
+//_createfx generated. Do not touch!!
+main(){}

--- a/maps/createfx/mp_rust_long_fx.gsc
+++ b/maps/createfx/mp_rust_long_fx.gsc
@@ -1,0 +1,2 @@
+//_createfx generated. Do not touch!!
+main(){}

--- a/maps/createfx/mp_shipment_fx.gsc
+++ b/maps/createfx/mp_shipment_fx.gsc
@@ -1,0 +1,2 @@
+//_createfx generated. Do not touch!!
+main(){}

--- a/maps/createfx/mp_shipment_long_fx.gsc
+++ b/maps/createfx/mp_shipment_long_fx.gsc
@@ -1,0 +1,2 @@
+//_createfx generated. Do not touch!!
+main(){}

--- a/maps/createfx/mp_storm_spring_fx.gsc
+++ b/maps/createfx/mp_storm_spring_fx.gsc
@@ -1,0 +1,2 @@
+//_createfx generated. Do not touch!!
+main(){}

--- a/maps/mp/mp_abandon.gsc
+++ b/maps/mp/mp_abandon.gsc
@@ -1,1 +1,27 @@
-main(){maps\mp\mp_abandon_precache::main();maps\mp\_destructible_dlc2::main();maps\mp\_destructible_dlc::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_abandon");setdvar("r_specularcolorscale","2.5");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.452);setdvar("r_lightGridContrast",0);setdvar("compassmaxrange","1800");game["attackers"]="allies";game["defenders"]="axis";}
+
+main()
+{
+
+	maps\mp\mp_abandon_precache::main();
+	maps\createart\mp_abandon_art::main();
+	//maps\mp\mp_abandon_fx::main();
+
+	maps\mp\_destructible_dlc2::main(); // call before _load
+	maps\mp\_destructible_dlc::main(); // call before _load
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_abandon" );
+
+	//ambientPlay( "ambient_mp_abandon" );
+
+
+	setdvar( "r_specularcolorscale", "2.5" );
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.452 );
+	setdvar( "r_lightGridContrast", 0 );
+	
+	setdvar( "compassmaxrange", "1800" );
+
+	game[ "attackers" ] = "allies";
+	game[ "defenders" ] = "axis";
+}

--- a/maps/mp/mp_afghan.gsc
+++ b/maps/mp/mp_afghan.gsc
@@ -1,3 +1,24 @@
 #include maps\mp\_utility;
 #include common_scripts\utility;
-main(){maps\mp\mp_afghan_precache::main();maps\mp\_explosive_barrels::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_afghan");setdvar("compassmaxrange","3000");game["attackers"]="allies";game["defenders"]="axis";setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.2);setdvar("r_lightGridContrast",0);}
+
+main()
+{
+	maps\mp\mp_afghan_precache::main();
+	maps\createart\mp_afghan_art::main();
+	//maps\mp\mp_afghan_fx::main();
+	maps\mp\_explosive_barrels::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_afghan" );
+	
+	setdvar( "compassmaxrange", "3000" );
+
+	//ambientPlay( "ambient_mp_desert" );
+
+	game[ "attackers" ] = "allies";
+	game[ "defenders" ] = "axis";
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.2 );
+	setdvar( "r_lightGridContrast", 0 );	
+}

--- a/maps/mp/mp_bloc.gsc
+++ b/maps/mp/mp_bloc.gsc
@@ -1,1 +1,20 @@
-main(){maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_bloc");game["attackers"]="axis";game["defenders"]="allies";setdvar("compassmaxrange","2000");level.airstrikeHeightScale=1.8;}
+main()
+{
+	maps\createart\mp_bloc_art::main();
+	//maps\mp\mp_bloc_fx::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_bloc" );
+
+	setdvar( "compassmaxrange", "2000" );
+	
+    //ambientPlay( "ambient_trainer_ext2" ); 
+
+	game["attackers"] = "axis";
+	game["defenders"] = "allies";
+
+	// raise up planes to avoid them flying through buildings
+	level.airstrikeHeightScale = 1.8;
+	
+	setdvar( "r_specularcolorscale", "2" );
+}

--- a/maps/mp/mp_bloc_sh.gsc
+++ b/maps/mp/mp_bloc_sh.gsc
@@ -1,0 +1,23 @@
+main()
+{
+	maps\createart\mp_bloc_sh_art::main();
+	maps\mp\mp_bloc_sh_precache::main();
+	maps\createfx\mp_bloc_sh_fx::main();
+	//maps\mp\mp_bloc_sh_fx::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_bloc_sh" );
+
+	setdvar( "compassmaxrange", "2000" );
+	
+    //ambientPlay( "ambient_trainer_ext2" ); 
+
+	game["attackers"] = "axis";
+	game["defenders"] = "allies";
+
+	// raise up planes to avoid them flying through buildings
+	level.airstrikeHeightScale = 1.8;
+	
+	setdvar( "r_specularcolorscale", "2.2" );
+	setdvar( "r_diffusecolorscale", "1.2" );
+}

--- a/maps/mp/mp_bog_sh.gsc
+++ b/maps/mp/mp_bog_sh.gsc
@@ -1,0 +1,20 @@
+main()
+{
+	maps\mp\_load::main();
+
+	//maps\mp\mp_bog_sh_fx::main();
+	maps\mp\mp_bog_sh_precache::main();
+	
+	maps\createfx\mp_bog_sh_fx::main();
+	maps\createart\mp_bog_sh_art::main();
+	
+	
+	maps\mp\_compass::setupMiniMap("compass_map_mp_bog_sh");
+
+	//ambientPlay("ambient_crossfire");
+
+	game["attackers"] = "axis";
+	game["defenders"] = "allies";
+	
+	setDvar("compassmaxrange","1800");
+}

--- a/maps/mp/mp_boneyard.gsc
+++ b/maps/mp/mp_boneyard.gsc
@@ -1,1 +1,23 @@
-main(){maps\mp\mp_boneyard_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_boneyard");setdvar("compassmaxrange","1700");game["attackers"]="allies";game["defenders"]="axis";setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.19);setdvar("r_lightGridContrast",.4);if(level.ps3)setdvar("sm_sunShadowScale","0.7");}
+main()
+{
+	maps\mp\mp_boneyard_precache::main();
+
+	//maps\mp\mp_boneyard_fx::main();
+	maps\createart\mp_boneyard_art::main();
+	maps\mp\mp_boneyard_precache::main();
+	maps\mp\_load::main();
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_boneyard" );
+	setdvar( "compassmaxrange", "1700" );
+
+	//ambientPlay( "ambient_mp_desert" );
+
+	game[ "attackers" ] = "axis";
+	game[ "defenders" ] = "allies";
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.19 );
+	setdvar( "r_lightGridContrast", .4 );
+
+	if ( level.ps3 )
+		setdvar( "sm_sunShadowScale", "0.7" ); // ps3 optimization
+}

--- a/maps/mp/mp_brecourt.gsc
+++ b/maps/mp/mp_brecourt.gsc
@@ -1,1 +1,25 @@
-main(){maps\mp\mp_brecourt_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_brecourt");game["attackers"]="allies";game["defenders"]="axis";setdvar("r_specularcolorscale","1");setdvar("compassmaxrange","4000");setdvar("sm_sunShadowScale",0.5);setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.11);setdvar("r_lightGridContrast",.29);}
+main()
+{
+	
+	maps\mp\mp_brecourt_precache::main();	
+	//maps\mp\mp_brecourt_fx::main();
+	maps\createart\mp_brecourt_art::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_brecourt" );
+
+	//ambientPlay( "ambient_mp_rural" );
+
+	game[ "attackers" ] = "allies";
+	game[ "defenders" ] = "axis";
+
+	setdvar( "r_specularcolorscale", "1" );
+
+	setdvar( "compassmaxrange", "4000" );
+	
+	setdvar( "sm_sunShadowScale", 0.5 );
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.11 );
+	setdvar( "r_lightGridContrast", .29 );
+}

--- a/maps/mp/mp_cargoship.gsc
+++ b/maps/mp/mp_cargoship.gsc
@@ -1,2 +1,22 @@
-#include common_scripts\utility;
-main(){maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_cargoship");setdvar("compassmaxrange","4000");game["attackers"]="allies";game["defenders"]="axis";level.airstrikeHeightScale=1.8;}
+main()
+{
+	maps\mp\_load::main();
+	//maps\mp\mp_cargoship_fx::main();
+	
+	maps\createart\mp_cargoship_art::main();
+	maps\createfx\mp_cargoship_fx::main();
+	
+	//ambientPlay( "ambient_mp_rain" );
+
+    game["attackers"] = "axis";
+    game["defenders"] = "allies";
+ 
+    maps\mp\_compass::setupMiniMap( "compass_map_mp_cargoship" );
+
+	setdvar( "r_specularcolorscale", "1.5" );
+	
+	level.airstrikeHeightScale = 2;
+
+	setdvar("compassmaxrange","2100");
+
+}

--- a/maps/mp/mp_cargoship_sh.gsc
+++ b/maps/mp/mp_cargoship_sh.gsc
@@ -1,0 +1,19 @@
+main()
+{
+	maps\mp\_load::main();
+	//maps\mp\mp_cargoship_sh_fx::main();
+	
+	maps\createart\mp_cargoship_sh_art::main();
+	maps\createfx\mp_cargoship_sh_fx::main();
+	
+	//ambientPlay( "ambient_mp_snow" );
+	
+	game["attackers"] = "axis";
+	game["defenders"] = "allies";
+	
+	maps\mp\_compass::setupMiniMap("compass_map_mp_cargoship_sh");
+	
+	level.airstrikeHeightScale = 2;
+	
+	setdvar("compassmaxrange","2100");
+}

--- a/maps/mp/mp_checkpoint.gsc
+++ b/maps/mp/mp_checkpoint.gsc
@@ -1,1 +1,27 @@
-main(){maps\mp\mp_checkpoint_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_checkpoint");level.airstrikeHeightScale=1.5;game["attackers"]="axis";game["defenders"]="allies";setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.27);setdvar("r_lightGridContrast",1);setdvar("r_specularcolorscale","2");setdvar("compassmaxrange","1600");}
+main()
+{
+	maps\mp\mp_checkpoint_precache::main();
+	maps\createart\mp_checkpoint_art::main();
+	//maps\mp\mp_checkpoint_fx::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_checkpoint" );
+
+	// raise up planes to avoid them flying through buildings
+	level.airstrikeHeightScale = 1.5;
+
+	//ambientPlay( "ambient_mp_urban" );
+
+	game[ "attackers" ] = "axis";
+	game[ "defenders" ] = "allies";
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.27 );
+	setdvar( "r_lightGridContrast", 1 );
+
+	setdvar( "r_specularcolorscale", "2" );
+
+	setdvar( "compassmaxrange", "1600" );
+
+
+}

--- a/maps/mp/mp_compact.gsc
+++ b/maps/mp/mp_compact.gsc
@@ -1,2 +1,149 @@
 #include maps\mp\_utility;
-main(){maps\mp\mp_compact_precache::main();maps\mp\_destructible_dlc::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_compact");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.10);setdvar("r_lightGridContrast",1);setdvar("compassmaxrange","1700");game["attackers"]="allies";game["defenders"]="axis";}
+
+main()
+{
+	maps\mp\mp_compact_precache::main();
+	maps\createart\mp_compact_art::main();
+	//maps\mp\mp_compact_fx::main();
+
+	maps\mp\_destructible_dlc::main(); // call before _load
+	maps\mp\_load::main();
+	
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_compact" );
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.10 );
+	setdvar( "r_lightGridContrast", 1 );
+	setdvar( "compassmaxrange", "1700" );
+	
+	//ambientPlay( "ambient_mp_compact" );
+	
+	game["attackers"] = "allies";
+	game["defenders"] = "axis";
+	
+	//doMagnet();
+	
+	//level thread crusherControl();
+}
+
+doMagnet()
+{
+	strength = 18000;
+	if ( getdvar( "scr_compact_magnet_strength" ) != "" )
+		strength = getdvarfloat( "scr_compact_magnet_strength" );
+	if ( strength == 0 )
+		return;
+		
+	radius = 250;
+	if ( getdvar( "scr_compact_magnet_radius" ) != "" )
+		radius = getdvarfloat( "scr_compact_magnet_radius" );
+	if ( radius <= 0 )
+		return;
+	 
+	magnet = getent( "magnetorg", "targetname" );
+	Missile_CreateAttractorEnt( magnet, strength, radius );
+}
+
+crusherControl()
+{
+	//button = getEnt( "button01", "targetname" );
+	crusher = getEnt( "crusher01", "targetname" );
+
+	crushTop = getEnt( "crushtop01", "targetname" );
+	playerDetector = getEnt( "onelevator", "targetname" );
+	
+	upOrigin = crusher getOrigin();
+	downOrigin = upOrigin + (0,0,-128);
+
+	//button.origin = button.origin + (0,0,20);
+
+	crushTop thread triggerLinkThread( crusher );
+	crushTop thread crushEmThread();
+	playerDetector thread triggerLinkThread( crusher );
+	playerDetector thread playerDetectorThread();
+
+	//precacheString( &"MP_PRESS_TO_RAPPEL" ); 
+	//button setHintString( &"MP_PRESS_TO_RAPPEL" );
+	
+	for ( ;; )
+	{
+		/*
+		button makeUsable();
+		button waittill ( "trigger", player );
+		button playSound( "vending_machine_button_press" );
+		button makeUnusable();
+		*/
+		
+		// move down
+		crusher playSound( "elev_run_start" );
+		crusher playLoopSound( "elev_run_loop" );
+
+		crusher moveTo( downOrigin, 10.0 );		
+		crusher waittill ( "movedone" );
+
+		crusher stopLoopSound( "elev_run_loop" );
+		crusher playSound( "elev_run_end" );
+		
+		/*
+		button makeUsable();
+		button waittill ( "trigger", player );
+		button playSound( "vending_machine_button_press" );
+		button makeUnusable();
+		*/
+		
+		wait 2;
+		
+		// wait until a player gets on
+		playerDetector waittill( "trigger", player );
+		
+		// move up
+		crusher playSound( "elev_run_start" );
+		crusher playLoopSound( "elev_run_loop" );
+
+		crusher moveTo( upOrigin, 10.0 );		
+		crusher waittill ( "movedone" );
+
+		crusher stopLoopSound( "elev_run_loop" );
+		crusher playSound( "elev_run_end" );
+		
+		wait 2;
+		
+		// wait until no players are on
+		while ( gettime() - playerDetector.triggertime <= 2000 )
+			wait .05;
+	}
+}
+
+
+triggerLinkThread( crusher )
+{
+	for ( ;; )
+	{
+		self.origin = crusher.origin;
+		
+		wait ( 0.05 );
+	}
+}
+
+playerDetectorThread()
+{
+	self.triggertime = gettime();
+	for ( ;; )
+	{
+		self waittill( "trigger", player );
+		self.triggertime = gettime();
+	}
+}
+
+crushEmThread()
+{
+	crushBottom = getEnt( "crushbtm01", "targetname" );
+
+	for ( ;; )
+	{
+		self waittill ( "trigger", player );
+		
+		if ( player isTouching( crushBottom ) && isReallyAlive( player ) )
+			player _suicide();
+	}	
+}

--- a/maps/mp/mp_complex.gsc
+++ b/maps/mp/mp_complex.gsc
@@ -1,3 +1,26 @@
 #include maps\mp\_utility;
 #include common_scripts\utility;
-main(){maps\mp\mp_complex_precache::main();maps\mp\_destructible_dlc::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_complex");level.airstrikeHeightScale=2;game["attackers"]="allies";game["defenders"]="axis";setdvar("compassmaxrange","1500");}
+
+main()
+{
+	maps\mp\mp_complex_precache::main();
+	//maps\mp\mp_complex_fx::main();
+	maps\createart\mp_complex_art::main();
+	
+	maps\mp\_destructible_dlc::main(); // call before _load
+	
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_complex" );
+
+	//ambientPlay( "ambient_mp_complex" );
+
+	// raise up planes to avoid them flying through buildings
+	level.airstrikeHeightScale = 2;
+
+	game[ "attackers" ] = "allies";
+	game[ "defenders" ] = "axis";
+	
+	setdvar( "compassmaxrange", "1500" );
+	
+}

--- a/maps/mp/mp_crash.gsc
+++ b/maps/mp/mp_crash.gsc
@@ -1,1 +1,21 @@
-main(){maps\mp\mp_crash_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_crash_dlc");game["attackers"]="axis";game["defenders"]="allies";SetDvar("r_specularcolorscale","1");SetDvar("compassmaxrange","1600");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.10);setdvar("r_lightGridContrast",1);}
+main()
+{
+	maps\mp\mp_crash_precache::main();
+	//maps\mp\mp_crash_fx::main();
+	maps\createart\mp_crash_art::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_crash_dlc" );
+
+	//AmbientPlay( "ambient_mp_crash" );
+
+	game["attackers"] = "axis";
+	game["defenders"] = "allies";
+
+	SetDvar( "r_specularcolorscale", "1" );
+	SetDvar( "compassmaxrange", "1600" );
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.10 );
+	setdvar( "r_lightGridContrast", 1 );
+}

--- a/maps/mp/mp_crash_tropical.gsc
+++ b/maps/mp/mp_crash_tropical.gsc
@@ -1,0 +1,24 @@
+main()
+{
+	//maps\mp\mp_crash_tropical_fx::main();
+	maps\createfx\mp_crash_tropical_fx::main();
+	maps\mp\mp_crash_tropical_precache::main();
+	maps\createart\mp_crash_tropical_art::main();
+	
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_crash_dlc" );
+	setdvar( "compassmaxrange", "1600" );
+	
+	//AmbientPlay( "ambient_mp_favela" );
+
+	game["attackers"] = "axis";
+	game["defenders"] = "allies";
+
+	setdvar( "r_specularcolorscale", "2.117" );
+	setdvar( "r_diffusecolorscale", "1.35" );
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.10 );
+	setdvar( "r_lightGridContrast", 1 );
+}

--- a/maps/mp/mp_cross_fire.gsc
+++ b/maps/mp/mp_cross_fire.gsc
@@ -1,1 +1,21 @@
-main(){maps\mp\_load::main();maps\animated_models\foliage_palmtree_tall1::main();maps\animated_models\foliage_palmtree_bushy1::main();common_scripts\_destructible_types_anim_airconditioner::main();maps\mp\_compass::setupMiniMap("compass_map_mp_cross_fire");game["attackers"]="axis";game["defenders"]="allies";setdvar("compassmaxrange","2100");}
+main()
+{
+	maps\mp\_load::main();
+	
+	//maps\mp\mp_cross_fire_fx::main();
+	maps\mp\mp_cross_fire_precache::main();
+	
+	maps\createfx\mp_cross_fire_fx::main();
+	maps\createart\mp_cross_fire_art::main();
+	
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_cross_fire" );
+	
+	//ambientPlay("ambient_trainer_ext2");
+	
+	game[ "attackers" ] = "axis";
+	game[ "defenders" ] = "allies";
+	
+	setdvar( "r_specularcolorscale", "4.5" );
+
+	setdvar( "compassmaxrange", "2100" );
+}

--- a/maps/mp/mp_derail.gsc
+++ b/maps/mp/mp_derail.gsc
@@ -1,1 +1,20 @@
-main(){maps\mp\mp_derail_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_derail");game["attackers"]="allies";game["defenders"]="axis";setdvar("r_specularcolorscale","2.3");setdvar("compassmaxrange","4000");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1);setdvar("r_lightGridContrast",.4);}
+main()
+{
+	maps\mp\mp_derail_precache::main();
+	//maps\mp\mp_derail_fx::main();
+	maps\createart\mp_derail_art::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_derail" );
+
+	//ambientPlay( "ambient_mp_snow" );
+
+	game[ "attackers" ] = "axis";
+	game[ "defenders" ] = "allies";
+
+	setdvar( "r_specularcolorscale", "2.3" );
+	setdvar( "compassmaxrange", "4000" );
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1 );
+	setdvar( "r_lightGridContrast", .4 );
+}

--- a/maps/mp/mp_estate.gsc
+++ b/maps/mp/mp_estate.gsc
@@ -1,1 +1,26 @@
-main(){maps\mp\mp_estate_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_estate");game["attackers"]="allies";game["defenders"]="axis";setdvar("r_specularcolorscale","1.17");setdvar("compassmaxrange","3500");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.3);setdvar("r_lightGridContrast",0);if(level.ps3)setdvar("sm_sunShadowScale","0.5");else setdvar("sm_sunShadowScale","0.7");}
+main()
+{
+
+	maps\mp\mp_estate_precache::main();
+	maps\createart\mp_estate_art::main();
+	//maps\mp\mp_estate_fx::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_estate" );
+
+	//ambientPlay( "ambient_mp_estate" );
+
+	game[ "attackers" ] = "allies";
+	game[ "defenders" ] = "axis";
+
+	setdvar( "r_specularcolorscale", "1.17" );
+	setdvar( "compassmaxrange", "3500" );
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.3 );
+	setdvar( "r_lightGridContrast", 0 );
+
+	if ( level.ps3 )
+		setdvar( "sm_sunShadowScale", "0.5" ); // ps3 optimization
+	else
+		setdvar( "sm_sunShadowScale", "0.7" ); // optimization
+}

--- a/maps/mp/mp_estate_tropical.gsc
+++ b/maps/mp/mp_estate_tropical.gsc
@@ -1,0 +1,29 @@
+main()
+{
+
+	maps\mp\_load::main();
+	
+	//maps\mp\mp_estate_tropical_fx::main();
+	maps\mp\mp_estate_tropical_precache::main();
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_estate_tropical" );
+	
+	maps\createart\mp_estate_tropical_art::main();
+
+
+	
+	//ambientPlay( "ambient_mp_estate" );
+
+	game[ "attackers" ] = "allies";
+	game[ "defenders" ] = "axis";
+
+	setdvar( "r_specularcolorscale", "3" );
+	setdvar( "r_diffusecolorscale", "1.5" );
+	setdvar( "sm_sunsamplesizenear", "0.38" );
+	
+	setdvar( "compassmaxrange", "3500" );
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.3 );
+	setdvar( "r_lightGridContrast", 0 );
+
+}

--- a/maps/mp/mp_fav_tropical.gsc
+++ b/maps/mp/mp_fav_tropical.gsc
@@ -1,2 +1,31 @@
-#include common_scripts\utility;
-main(){maps\mp\_load::main();game["attackers"]="allies";game["defenders"]="axis";maps\mp\_compass::setupMiniMap("compass_map_mp_fav_tropical");setdvar("compassmaxrange","4000");}
+main()
+{
+	maps\mp\mp_fav_tropical_precache::main();
+
+	maps\createart\mp_fav_tropical_art::main();
+	//maps\mp\mp_fav_tropical_fx::main();
+
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_fav_tropical" );
+
+	// raise up planes to avoid them flying through buildings
+	level.airstrikeHeightScale = 1.5;
+
+	//ambientPlay( "ambient_mp_favela" );
+
+	switch ( level.gameType )
+	{	
+		case "oneflag":
+			game[ "attackers" ] = "allies";
+			game[ "defenders" ] = "axis";
+			break;
+		default:
+			game[ "attackers" ] = "axis";
+			game[ "defenders" ] = "allies";
+			break;
+	}
+
+	setdvar( "r_specularcolorscale", "2.8" );
+	setdvar( "compassmaxrange", "1500" );
+}

--- a/maps/mp/mp_favela.gsc
+++ b/maps/mp/mp_favela.gsc
@@ -1,1 +1,35 @@
-main(){maps\mp\mp_favela_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_favela");level.airstrikeHeightScale=1.5;switch(level.gameType){case"oneflag":game["attackers"]="allies";game["defenders"]="axis";break;default:game["attackers"]="axis";game["defenders"]="allies";break;}setdvar("r_specularcolorscale","2.8");setdvar("compassmaxrange","1500");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.25);setdvar("r_lightGridContrast",.45);}
+main()
+{
+	maps\mp\mp_favela_precache::main();
+
+	maps\createart\mp_favela_art::main();
+	//maps\mp\mp_favela_fx::main();
+
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_favela" );
+	//setExpFog( 270, 11488, 0.8, 0.8, 0.8, 0.1, 0 );
+
+	// raise up planes to avoid them flying through buildings
+	level.airstrikeHeightScale = 1.5;
+
+	//ambientPlay( "ambient_mp_favela" );
+
+	switch ( level.gameType )
+	{	
+		case "oneflag":
+			game[ "attackers" ] = "allies";
+			game[ "defenders" ] = "axis";
+			break;
+		default:
+			game[ "attackers" ] = "axis";
+			game[ "defenders" ] = "allies";
+			break;
+	}
+
+	setdvar( "r_specularcolorscale", "2.8" );
+	setdvar( "compassmaxrange", "1500" );
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.25 );
+	setdvar( "r_lightGridContrast", .45 );
+}

--- a/maps/mp/mp_firingrange.gsc
+++ b/maps/mp/mp_firingrange.gsc
@@ -1,0 +1,458 @@
+#include maps\mp\_utility;
+#include common_scripts\utility;
+
+main()
+{
+	maps\mp\_load::main();
+	
+	//maps\mp\mp_firingrange_fx::main();
+	maps\createart\mp_firingrange_art::main();
+	maps\createfx\mp_firingrange_fx::main();
+	
+	maps\mp\_explosive_barrels::main();
+	
+	//ambientPlay( "ambient_mp_estate" );
+	
+	maps\mp\_compass::setupMiniMap("compass_map_mp_firingrange");
+	
+	setdvar ( "r_diffusecolorscale", "1.5");
+
+	/****** GET ENTITIES ******/
+	//TRIGGERS
+	alleyTrigger = getent("alleyTrigger","targetname");
+	windowTrigger = getent("triggerwindowTarget","targetname");
+
+	//TARGETS
+	target1 = getent("fieldTarget_BackLeft","targetname");	
+	target2 = getent("fieldTarget_FrontLeft","targetname");	
+	target3 = getent("fieldTarget_Middle","targetname");
+	target4 = getent("fieldTarget_BackRight","targetname");
+	target5 = getent("fieldTarget_FrontRight","targetname");
+	target6 = getent("trenchTarget_GroundWall","targetname");
+	target7 = getent("trailerTarget_Window","targetname");
+	target8 = getent("alleyTarget_Cover","targetname");
+	target9 = getent("alleyTarget_Path","targetname");
+	target10 = getent("centerTarget_Sandbags","targetname");
+	target11 = getent("towerTarget_Front","targetname");
+	target12 = getent("towerTarget_Back","targetname");
+	target13 = getent("centerTarget_Path","targetname");
+	target14 = getent("centerTarget_PathBunkerL","targetname");
+	target15 = getent("centerTarget_PathBunkerR","targetname");
+	target16 = getent("steelBuildingTarget_Slide1","targetname");
+	target17 = getent("steelBuildingTarget_PopUp","targetname");
+	target18 = getent("target_alleyWindow1","targetname");
+	target19 = getent("target_alleyWindow2","targetname");
+	target20 = getent("target_alleyWindow3","targetname");
+
+	//TARGET LIGHTs
+
+	//Props
+	targetLight1_off = getent("steelBuildingTargetLight1_off", "targetname");
+	targetLight1_on = getent("steelBuildingTargetLight1_on", "targetname");
+
+	targetLight2_off = getent("steelBuildingTargetLight2_off", "targetname");
+	targetLight2_on = getent("steelBuildingTargetLight2_on", "targetname");
+
+	//Lights
+
+	level.const_fx_exploder_red_light_1 = 1001;
+	level.const_fx_exploder_red_light_2 = 1002;
+
+	//LOUDSPEAKERS
+	speaker1 = getent("loudspeaker1", "targetname");
+	speaker2 = getent("loudspeaker2", "targetname");
+
+	//PROPANE TANKS
+	/*propaneTank1 = getent("explodingPropaneTank","targetname");
+	propaneTank2 = getent("explodingPropaneTank2","targetname");
+	propaneTank3 = getent("explodingPropaneTank3","targetname");*/
+
+	/****** HIDE ON TARGET LIGHTS ******/
+	//Keep the on versions of the light model hidden until appropriate target takes damage.
+	targetLight1_on Hide();
+	targetLight2_on Hide();
+
+	/****** DAMAGE OBJECTS ********/
+
+	//TARGETS
+	target1 SetCanDamage(true);
+	target2 SetCanDamage(true);
+	target3 SetCanDamage(true);
+	target4 SetCanDamage(true);
+	target5 SetCanDamage(true);
+	target8 SetCanDamage(true);
+	target9 SetCanDamage(true);
+	target10 SetCanDamage(true);
+	target13 SetCanDamage(true);
+	target14 SetCanDamage(true);
+	target15 SetCanDamage(true);
+	target16 SetCanDamage(true);
+	target17 SetCanDamage(true);
+	target18 SetCanDamage(true);
+	target19 SetCanDamage(true);
+	target20 SetCanDamage(true);
+	
+	target1 thread damageTarget(1);
+	target2 thread damageTarget(1);
+	target3 thread damageTarget(1);
+	target4 thread damageTarget(1);
+	target5 thread damageTarget(1);
+	target8 thread damageTarget(2);
+	target9 thread damageTarget(2);
+	target10 thread damageTarget(2);
+	target13 thread damageTarget(2);
+	target14 thread damageTarget(3);
+	target15 thread damageTarget(3);
+	//target16 thread damageTargetLights(targetLight1_on, targetLight1_off, speaker1, "amb_target_buzzer", level.const_fx_exploder_red_light_2 );
+	//target17 thread damageTargetLights(targetLight2_on, targetLight2_off, speaker2, "amb_target_buzzer", level.const_fx_exploder_red_light_1 );
+	target18 thread damageTarget(4);
+	target19 thread damageTarget(4);
+	target20 thread damageTarget(5);
+
+	//PROPANE TANKS
+	/*propaneTank1 SetCanDamage(true);
+	propaneTank2 SetCanDamage(true);
+	propaneTank3 SetCanDamage(true);
+
+	propaneTank1 thread damagePropaneTank("mpl_kls_artillery_impact");
+	propaneTank2 thread damagePropaneTank("mpl_kls_artillery_impact");
+	propaneTank3 thread damagePropaneTank("mpl_kls_artillery_impact");*/
+
+	
+	/****** MOVE TARGETS ******/
+	//Sliding Targets
+	target1 thread moveTarget(4, 220, 10.1);	
+	target2 thread moveTarget(4, 220, 5.2);	
+	target3 thread moveTarget(4, 220, 10.3);	
+	target4 thread moveTarget(3, 290, 8.4);	
+	target5 thread moveTarget(3, 285, 3);
+	target6 thread moveTarget(1, 228, 8.1);
+	target7 thread moveTarget(7, (57, 23, 0), 3);
+	target8 thread moveTarget(1, 250, 5.5);
+	target9 thread moveTarget(1, 146, 8.6);
+	target10 thread moveTarget(1, 165, 8.7);
+	target11 thread moveTarget(4, 136, 5.05);
+	target12 thread moveTarget(3, 136, 7.15);
+	target13 thread moveTarget(1, 228, 8.25);
+	target16 thread moveTarget(4, 164, 5.35);
+	target17 thread moveTarget(5, 48, 5.45);
+	target18 thread moveTarget(3, 270, 8.55);
+	target19 thread moveTarget(6, 70, 6.65);
+	target20 thread moveTarget(1, 130, 5.75);
+
+
+
+	//Hinge Targets
+	//targetHinge1 thread rotateTarget(2, 90, 0.5, 3);	//-Z direction, 90 degrees, in .5 seconds, wait inbetween for 3 seconds.
+	target11 thread rotateTarget(2, 90, 0.5, 2);
+	target12 thread rotateTarget(1, 90, 0.7, 3);
+
+	//TRIGGERS
+	target9.triggeroff = true;
+	alleyTrigger thread triggerCheck(target9);
+	target7.triggeroff = true;
+	windowTrigger thread triggerCheck(target7);
+}
+
+triggerCheck(target)
+{
+	self endon("game_ended");
+	while(1)
+	{
+		self waittill("trigger", player);
+
+		//If the target is close enough to the player to cause a possible issue, tell the target to go back the other direction.
+		distance = Distance(target.origin, self.origin);
+		if(distance <= 90)
+		{
+			if( isDefined(target.triggeroff))
+				target.triggeroff = false; //Stop the target.
+
+			target notify("targetStopMoving");
+
+			while( isdefined( player) && player isTouching(self) && distance <= 90)
+			{
+				wait 0.1;
+			}
+			if( isDefined(target.triggeroff))
+				target.triggeroff = true; //Start the target.
+
+			target notify("targetStopMoving");
+		}
+	}
+}
+
+damageTarget(dir)
+{
+	self endon("game_ended");
+	while(1)
+	{
+		self waittill("damage", damage, attacker, direction);
+
+		switch(dir)
+		{
+		case 1:
+			self rotateroll(self.angles[1] + 90, .1);
+			wait(.2);
+			self rotateroll(self.angles[1] - 90, .1);
+			wait(.2);
+			self PlaySound ("amb_target_flip");
+			break;
+		case 2:
+		{
+			rotation = 1;
+			if ( isdefined( attacker ) && isPlayer( attacker ) )
+			{
+				//yaw = get2DYaw( attacker.origin, self.origin );
+				//if ( attacker.angles[1] > yaw ) 
+				//	rotation = -1;
+				
+			}
+			
+			self rotateyaw(self.angles[2] + (180 * rotation), .3);
+			self PlaySound ("amb_target_twirl");
+			self waittill("rotatedone");
+		}
+			break;
+		case 3:
+			self rotatepitch(self.angles[1] + 90, .1);
+			wait(.2);
+			self rotatepitch(self.angles[1] - 90, .1);
+			wait(.2);
+			self PlaySound ("amb_target_flip");
+			break;
+		case 4:
+			self rotateroll(self.angles[1] - 90, .1);
+			wait(.2);
+			self rotateroll(self.angles[1] + 90, .1);
+			wait(.2);
+			self PlaySound ("amb_target_flip");
+			break;
+		case 5:
+			self rotatepitch(self.angles[1] - 90, .1);
+			wait(.2);
+			self rotatepitch(self.angles[1] + 90, .1);
+			wait(.2);
+			self PlaySound ("amb_target_flip");
+			break;
+
+		}
+	}
+}
+
+//Pass in one of the following to define the start direction of the target: 1 for +y, 2 for -y, 3 for +x, 4 for -x, 5 for +Z, 6 for -Z.
+//Pass in the distance in units the target is to travel.
+//Pass in the ammount of time in seconds that it will take the target to travel that distance.
+moveTarget(dir, dis, speed)
+{
+	self endon("game_ended");
+	keepMoving = true;	//Local var to decide if the target needs to be paused or not.
+
+	//Get the targets starting position or nearPos
+	startPOS = self.origin;
+	//Find out the targets far position.
+	FarPOS = self.origin;
+	
+	sound = Spawn ("script_origin", self.origin);
+	sound LinkTo(self);
+	sound PlayLoopSound ("amb_target_chain");
+	
+	switch(dir)
+	{
+	case 1://+Y
+		farPOS = self.origin + (0,dis,0);
+		break;
+	case 2://-Y
+		farPOS = self.origin - (0,dis,0);
+		break;
+	case 3://+X
+		farPOS = self.origin + (dis,0,0);
+		break;
+	case 4://-X
+		farPOS = self.origin - (dis,0,0);
+		break;
+	case 5://+Z
+		farPOS = self.origin + (0,0,dis);
+		break;
+	case 6://-Z
+		farPOS = self.origin - (0,0,dis);
+		break;
+	case 7://Custom
+		farPOS = self.origin - dis;
+		break;
+	}
+	
+	//Move the target
+	while(1)
+	{
+		if( isDefined(self.triggeroff)) //Does the target have the Key triggeroff? If so, set keepMoving to its value.
+			keepMoving = self.triggeroff;
+
+		switch(dir)
+		{
+		case 1: //+Y
+			self moveto(farPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+
+			if( isDefined(self.triggeroff)) //Does the target have the Key triggeroff? If so, set keepMoving to its value.
+				keepMoving = self.triggeroff;
+
+			if(keepMoving == false)
+				break;
+			self moveto(startPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+			break;
+		case 2: //-Y
+			self moveto(farPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+
+			if( isDefined(self.triggeroff)) //Does the target have the Key triggeroff? If so, set keepMoving to its value.
+				keepMoving = self.triggeroff;
+
+			if(keepMoving == false)
+				break;
+			self moveto(startPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+			break;
+		case 3: //+X
+			self moveto(farPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+
+			if( isDefined(self.triggeroff)) //Does the target have the Key triggeroff? If so, set keepMoving to its value.
+				keepMoving = self.triggeroff;
+
+			if(keepMoving == false)
+				break;
+			self moveto(startPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+			break;
+		case 4: //-X
+			self moveto(farPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+
+			if( isDefined(self.triggeroff)) //Does the target have the Key triggeroff? If so, set keepMoving to its value.
+				keepMoving = self.triggeroff;
+
+			if(keepMoving == false)
+				break;
+			self moveto(startPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+			break;
+		case 5: //+Z
+			self moveto(farPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+
+			if( isDefined(self.triggeroff)) //Does the target have the Key triggeroff? If so, set keepMoving to its value.
+				keepMoving = self.triggeroff;
+
+			if(keepMoving == false)
+				break;
+			self moveto(startPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+			break;
+		case 6: //-Z
+			self moveto(farPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+			if( isDefined(self.triggeroff)) //Does the target have the Key triggeroff? If so, set keepMoving to its value.
+				keepMoving = self.triggeroff;
+
+			if(keepMoving == false)
+				break;
+			self moveto(startPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+			break;
+		case 7: //Custom
+			if(keepMoving == false)
+				self waittill("targetStopMoving"); //Wait here till the player leaves the trigger.
+
+			self moveto(farPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+			if( isDefined(self.triggeroff)) //Does the target have the Key triggeroff? If so, set keepMoving to its value.
+				keepMoving = self.triggeroff;
+
+			if(keepMoving == false)
+				self waittill("targetStopMoving"); //Wait here till the player leaves the trigger.
+			self moveto(StartPOS, speed);
+			self waittill_any("movedone","targetStopMoving");
+			self PlaySound ("amb_target_stop");
+		
+			
+		}
+	}
+}
+
+
+rotateTarget(dir, deg, speed, pauseTime)
+{
+	self endon("game_ended");
+	while(1)
+	{
+		switch(dir)
+		{
+		case 1:	//+Z
+			self rotateyaw(self.angles[2] + deg, speed);
+			self PlaySound ("amb_target_rotate");
+			wait(pauseTime);
+			self rotateyaw(self.angles[2] - deg, speed);
+			self PlaySound ("amb_target_rotate");
+			wait(pauseTime);
+			break;
+		case 2: //-Z
+			self rotateyaw(self.angles[2] - deg, speed);
+			self PlaySound ("amb_target_rotate");
+			wait(pauseTime);
+			self rotateyaw(self.angles[2] + deg, speed);
+			self PlaySound ("amb_target_rotate");
+			wait(pauseTime);
+			break;
+		case 3: //+X
+			self rotateroll(self.angles[0] + deg, speed);
+			self PlaySound ("amb_target_rotate");
+			wait(pauseTime);
+			self rotateroll(self.angles[0] - deg, speed);
+			self PlaySound ("amb_target_rotate");
+			wait(pauseTime);
+			break;
+		case 4: //-X
+			self rotateroll(self.angles[0] - deg, speed);
+			self PlaySound ("amb_target_rotate");
+			wait(pauseTime);
+			self rotateroll(self.angles[0] + deg, speed);
+			self PlaySound ("amb_target_rotate");
+			wait(pauseTime);
+			break;
+		case 5: //+Y
+			self rotateroll(self.angles[1] + deg, speed);
+			self PlaySound ("amb_target_rotate");
+			wait(pauseTime);
+			self rotateroll(self.angles[1] - deg, speed);
+			self PlaySound ("amb_target_rotate");
+			wait(pauseTime);
+			break;
+		case 6: //-Y
+			self rotatepitch(self.angles[1] - deg, speed);
+			wait(pauseTime);
+			self rotatepitch(self.angles[1] + deg, speed);
+			wait(pauseTime);
+			break;
+		case 7: //Custom
+			self rotateto( (self.angles[0] + 90, self.angles[1] - 90, self.angles[2] + 45), speed);
+			wait(pauseTime);
+			self rotateto( (self.angles[0] - 90, self.angles[1] + 90, self.angles[2] - 45), speed);
+			wait(pauseTime);
+		}
+	}
+}

--- a/maps/mp/mp_fuel2.gsc
+++ b/maps/mp/mp_fuel2.gsc
@@ -1,1 +1,15 @@
-main(){maps\mp\mp_fuel2_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_fuel2");game["attackers"]="allies";game["defenders"]="axis";}
+main()
+{
+	maps\mp\mp_fuel2_precache::main();
+	//maps\mp\mp_fuel2_fx::main();
+	//maps\createart\mp_fuel2_art::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_fuel2" );
+	setExpFog( 500, 8000, 0.501961, 0.501961, 0.45098, 0.5, 0 );
+
+	//ambientPlay( "ambient_mp_fuel" );
+
+	game[ "attackers" ] = "allies";
+	game[ "defenders" ] = "axis";
+}

--- a/maps/mp/mp_highrise.gsc
+++ b/maps/mp/mp_highrise.gsc
@@ -1,3 +1,149 @@
 #include maps\mp\_utility;
 #include common_scripts\utility;
-main(){maps\mp\mp_highrise_precache::main();maps\mp\_explosive_barrels::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_highrise");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.11);setdvar("r_lightGridContrast",.9);VisionSetNaked("mp_highrise");game["attackers"]="axis";game["defenders"]="allies";level.airstrikeHeightScale=3;setdvar("compassmaxrange","2100");}Elevator(elevatorID){elevator=getent(elevatorID,"targetname");elevFloors=[];elevFloors[0]=getent(elevatorID+"_floor1","targetname").origin;elevFloors[1]=getent(elevatorID+"_floor2","targetname").origin;moveSpeed=192;waitTime=2.0;floorIndex=0;while(1){newPos=elevFloors[floorIndex];moveDist=distance(elevator.origin,newPos);if(moveDist<=0.0){floorIndex=(floorIndex+1)%elevFloors.size;continue;}moveTime=moveDist/moveSpeed;elevator moveTo(newPos,moveTime,moveTime*0.25,moveTime*0.25);floorIndex=(floorIndex+1)%elevFloors.size;wait moveTime+waitTime;}}SetupRappel(){trigs=getentarray("rappeltrigger","targetname");foreach(trig in trigs){org=getent(trig.target,"targetname");trig.rappelPoint=org.origin;trig.dir=anglesToForward(org.angles);org delete();trig thread RappelThink();}foreach(trig in trigs){org=getent(trig.target,"targetname");if(isdefined(org))org delete();}}RappelThink(){while(1){self waittill("trigger",player);if(!isPlayer(player))continue;if(!player isOnGround())continue;if(isdefined(player.rapelling))continue;player thread Rappel(self);}}Rappel(trig){toRappelPoint=trig.rappelPoint-self.origin;rappelPoint=self.origin+vectordot(toRappelPoint,trig.dir)*trig.dir;rappelPoint=(rappelPoint[0],rappelPoint[1],trig.rappelPoint[2]);upTime=.5;overTime=.75;downSpeed=512;upPoint=self.origin;upPoint=(upPoint[0],upPoint[1],rappelPoint[2]);overPoint=rappelPoint+trig.dir*20;tracePosition=playerPhysicsTrace(overPoint,overPoint+(0,0,-10000),false,self);downPoint=tracePosition+(0,0,16);org=spawn("script_origin",self.origin);org hide();self.rapelling=true;self _disableWeapon();self linkto(org);self PlayerLinkedOffsetEnable();org moveto(upPoint,upTime,0,0);org waittill("movedone");org moveto(overPoint,overTime,0,0);org waittill("movedone");downTime=distance(overPoint,downPoint)/downSpeed;org moveto(downPoint,downTime,0,0);org waittill("movedone");self _enableWeapon();self unlink();org delete();self.rapelling=undefined;}
+
+main()
+{
+	maps\mp\mp_highrise_precache::main();
+	maps\createart\mp_highrise_art::main();
+	//maps\mp\mp_highrise_fx::main();
+	maps\mp\_explosive_barrels::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_highrise" );
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.11 );
+	setdvar( "r_lightGridContrast", .9 );
+
+	VisionSetNaked( "mp_highrise" );
+	//ambientPlay( "embient_mp_highrise" );
+
+	game[ "attackers" ] = "axis";
+	game[ "defenders" ] = "allies";
+	
+	// raise up planes to avoid them flying through buildings
+	level.airstrikeHeightScale = 3;
+
+	setdvar( "compassmaxrange", "2100" );
+	//thread Elevator( "elev1" );
+	//thread Elevator( "elev2" );
+	//thread Elevator( "elev3" );	
+	//thread Elevator( "elev4" );
+
+	//thread SetupRappel();
+}
+
+Elevator( elevatorID )
+{
+	elevator = getent( elevatorID, "targetname" );
+	elevFloors = [];
+	elevFloors[ 0 ] = getent( elevatorID + "_floor1", "targetname" ).origin;
+	elevFloors[ 1 ] = getent( elevatorID + "_floor2", "targetname" ).origin;
+
+	moveSpeed = 192;// units / second
+
+	waitTime = 2.0;
+
+	floorIndex = 0;
+	while ( 1 )
+	{
+		newPos = elevFloors[ floorIndex ];
+		moveDist = distance( elevator.origin, newPos );
+		if ( moveDist <= 0.0 )
+		{
+			floorIndex = ( floorIndex + 1 ) % elevFloors.size;
+			continue;
+		}
+		moveTime = moveDist / moveSpeed;
+		elevator moveTo( newPos, moveTime, moveTime * 0.25, moveTime * 0.25 );
+
+		floorIndex = ( floorIndex + 1 ) % elevFloors.size;
+
+		wait moveTime + waitTime;
+	}
+}
+
+
+
+SetupRappel()
+{
+	// Press and hold ^3[{+activate}]^7 to rappel
+	//precacheString( &"MP_PRESS_TO_RAPPEL" );
+	trigs = getentarray( "rappeltrigger", "targetname" );
+	foreach ( trig in trigs )
+	{
+		org = getent( trig.target, "targetname" );
+		trig.rappelPoint = org.origin;
+		trig.dir = anglesToForward( org.angles );
+		org delete();
+		trig thread RappelThink();
+	}
+	foreach ( trig in trigs )
+	{
+		org = getent( trig.target, "targetname" );
+		if ( isdefined( org ) )
+			org delete();
+	}
+}
+
+RappelThink()
+{
+	// Press and hold ^3[{+activate}]^7 to rappel
+	//self setHintString( &"MP_PRESS_TO_RAPPEL" );
+
+	while ( 1 )
+	{
+		self waittill( "trigger", player );
+		if ( !isPlayer( player ) )
+			continue;
+
+		if ( !player isOnGround() )
+			continue;
+
+		if ( isdefined( player.rapelling ) )
+			continue;
+
+		player thread Rappel( self );
+	}
+}
+
+Rappel( trig )
+{
+	toRappelPoint = trig.rappelPoint - self.origin;
+	rappelPoint = self.origin + vectordot( toRappelPoint, trig.dir ) * trig.dir;
+	rappelPoint = ( rappelPoint[ 0 ], rappelPoint[ 1 ], trig.rappelPoint[ 2 ] );
+
+	upTime = .5;// sec
+	overTime = .75;// sec
+	downSpeed = 512;// units / sec
+
+	upPoint = self.origin;
+	upPoint = ( upPoint[ 0 ], upPoint[ 1 ], rappelPoint[ 2 ] );
+	overPoint = rappelPoint + trig.dir * 20;
+	tracePosition = playerPhysicsTrace( overPoint, overPoint + ( 0, 0, -10000 ), false, self );
+	downPoint = tracePosition + ( 0, 0, 16 );
+
+	org = spawn( "script_origin", self.origin );
+	org hide();
+
+	self.rapelling = true;
+	self _disableWeapon();
+	self linkto( org );
+	self PlayerLinkedOffsetEnable();
+
+	org moveto( upPoint, upTime, 0, 0 );
+	org waittill( "movedone" );
+	org moveto( overPoint, overTime, 0, 0 );
+	org waittill( "movedone" );
+
+	downTime = distance( overPoint, downPoint ) / downSpeed;
+
+	org moveto( downPoint, downTime, 0, 0 );
+	org waittill( "movedone" );
+
+	self _enableWeapon();
+	self unlink();
+	org delete();
+
+	self.rapelling = undefined;
+}

--- a/maps/mp/mp_invasion.gsc
+++ b/maps/mp/mp_invasion.gsc
@@ -1,1 +1,25 @@
-main(){maps\mp\mp_invasion_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_invasion");level.airstrikeHeightScale=1.5;game["attackers"]="allies";game["defenders"]="axis";setdvar("r_specularcolorscale","2.5");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.25);setdvar("r_lightGridContrast",.5);setdvar("compassmaxrange","2500");}
+main()
+{
+	maps\mp\mp_invasion_precache::main();
+	maps\createart\mp_invasion_art::main();
+	//maps\mp\mp_invasion_fx::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_invasion" );
+
+	// raise up planes to avoid them flying through buildings
+	level.airstrikeHeightScale = 1.5;
+
+	//ambientPlay( "ambient_mp_urban" );
+
+	game[ "attackers" ] = "axis";
+	game[ "defenders" ] = "allies";
+
+	setdvar( "r_specularcolorscale", "2.5" );
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.25 );
+	setdvar( "r_lightGridContrast", .5 );
+	setdvar( "compassmaxrange", "2500" );
+
+
+}

--- a/maps/mp/mp_killhouse.gsc
+++ b/maps/mp/mp_killhouse.gsc
@@ -1,1 +1,19 @@
-main(){maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_killhouse");game["attackers"]="allies";game["defenders"]="axis";setdvar("compassmaxrange","1800");}
+main()
+{
+	//maps\mp\mp_killhouse_fx::main();
+	maps\createart\mp_killhouse_art::main();
+	//maps\createfx\mp_killhouse_fx::main();
+	
+	maps\mp\_load::main();
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_killhouse" );
+
+	//ambientPlay("ambient_scoutsniper_ext0");
+
+	game[ "attackers" ] = "allies";
+	game[ "defenders" ] = "axis";
+
+	setdvar("compassmaxrange","2200");
+	setdvar("r_specularcolorscale", "1");
+	setdvar("sm_sunSampleSizeNear", "0.35"); //This fixes the shadow errors
+	
+}

--- a/maps/mp/mp_nightshift.gsc
+++ b/maps/mp/mp_nightshift.gsc
@@ -1,2 +1,60 @@
 #include maps\mp\_utility;
-main(){maps\mp\mp_nightshift_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_nightshift");setdvar("compassmaxrange","2400");VisionSetNaked("mp_nightshift");game["attackers"]="axis";game["defenders"]="allies";setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.2);setdvar("r_lightGridContrast",1);level.airstrikeHeightScale=1.5;}
+
+main()
+{
+	maps\mp\mp_nightshift_precache::main();
+	//maps\mp\mp_nightshift_fx::main();
+	maps\createart\mp_nightshift_art::main();
+	maps\mp\_load::main();
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_nightshift" );
+	setdvar( "compassmaxrange", "2400" );
+
+	//ambientPlay( "ambient_mp_urban" );
+	VisionSetNaked( "mp_nightshift" );
+
+	game[ "attackers" ] = "axis";
+	game[ "defenders" ] = "allies";
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.2 );
+	setdvar( "r_lightGridContrast", 1 );
+	
+	// raise up planes to avoid them flying through buildings
+	level.airstrikeHeightScale = 1.5;
+
+	level._effect["explosive_fx"] = loadfx("explosions/tanker_explosion");
+	level._effect[ "train_dust" ] = loadfx( "dust/train_dust" );
+	level._effect[ "train_dust_linger" ] = loadfx( "dust/train_dust_linger" );
+	
+	thread hallwayPlunger();	
+}
+
+hallwayPlunger()
+{
+	plunger = getEnt( "plunger", "targetname" );
+	
+	if ( !isDefined( plunger ) )
+		return;
+		
+	plunger waittill ( "trigger" );
+	
+	explosives = getEntArray( plunger.target, "targetname" );
+	
+	foreach ( explosive in explosives )
+	{
+		wait ( 0.25 );
+
+		rot = randomfloat(360);
+		explosionEffect = spawnFx( level._effect["explosive_fx"], explosive.origin + (0,0,0), (0,0,1), (cos(rot),sin(rot),0) );
+		triggerFx( explosionEffect );
+		
+		//playFx( level._effect["explosive_fx"], explosive.origin, explosive.angles );
+		radiusDamage( explosive.origin, 384, 200, 30 );
+		//explosive playSound( "detpack_explo_default" );
+		thread playSoundinSpace( "exp_suitcase_bomb_main", explosive.origin );
+		explosive delete();		
+	}
+	
+	plunger delete();
+	return;	
+}

--- a/maps/mp/mp_nuked.gsc
+++ b/maps/mp/mp_nuked.gsc
@@ -1,2 +1,139 @@
 #include common_scripts\utility;
-main(){maps\mp\_load::main();game["attackers"]="allies";game["defenders"]="axis";maps\mp\_compass::setupMiniMap("compass_map_mp_nuked");array_thread(getentarray("compassTriggers","targetname"),::compass_triggers_think);}self_delete(){self delete();}compass_triggers_think(){assertex(isdefined(self.script_noteworthy),"compassTrigger at "+self.origin+" needs to have a script_noteworthy with the name of the minimap to use");while(true){wait(1);self waittill("trigger");maps\mp\_compass::setupMiniMap(self.script_noteworthy);}}createSpawnpoint(classname,origin,yaw){spawnpoint=spawn("script_origin",origin);spawnpoint.angles=(0,yaw,0);if(!isdefined(level.extraspawnpoints))level.extraspawnpoints=[];if(!isdefined(level.extraspawnpoints[classname]))level.extraspawnpoints[classname]=[];level.extraspawnpoints[classname][level.extraspawnpoints[classname].size]=spawnpoint;}
+ 
+main()
+{
+	maps\mp\_load::main();
+	//maps\mp\mp_nuked_fx::main();
+
+	//setexpfog(874.792, 2740, 0.776471, 0.588235, 0.47451, 0.5, 0, 0.803922, 0.717647, 0.6, (-0.432962, -0.395847, 0.809845), 0, 61.0525, 5.68252);
+	setexpfog(1074.792, 3540, 0.934471, 0.838235, 0.694513, 0.5, 0, 0.803922, 0.717647, 0.6, (-0.432962, -0.395847, 0.809845), 0, 61.0525, 5.68252);
+	//ambientPlay( "ambient_mp_desert" );
+
+	game[ "attackers" ] = "allies";
+	game[ "defenders" ] = "axis";
+ 
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_nuked" );
+	//setdvar( "compassmaxrange", "4000" );
+	
+	nuked_doomsday_clock_init();
+	level thread nuked_population_sign_think();
+ 
+	array_thread( getentarray( "compassTriggers", "targetname" ), ::compass_triggers_think );
+}
+ 
+self_delete()
+{
+	self delete();
+}
+
+
+compass_triggers_think()
+{
+	assertex( isdefined( self.script_noteworthy ), "compassTrigger at " + self.origin + " needs to have a script_noteworthy with the name of the minimap to use" );
+	while( true )
+	{
+		wait( 1 );
+		self waittill( "trigger" );
+		maps\mp\_compass::setupMiniMap( self.script_noteworthy );
+	}
+}
+ 
+createSpawnpoint( classname, origin, yaw )
+{
+	spawnpoint = spawn( "script_origin", origin );
+	spawnpoint.angles = (0,yaw,0);
+       
+	if ( !isdefined( level.extraspawnpoints ) )
+		level.extraspawnpoints = [];
+	if ( !isdefined( level.extraspawnpoints[classname] ) )
+		level.extraspawnpoints[classname] = [];
+	level.extraspawnpoints[classname][ level.extraspawnpoints[classname].size ] = spawnpoint;
+}
+
+nuked_population_sign_think()
+{
+        tens_model = GetEnt( "counter_tens", "targetname" );
+        ones_model = GetEnt( "counter_ones", "targetname" );
+ 
+        step = ( 360 / 10 ); // 10 digits (0-9) on the dial
+ 
+        // put the dials at 0
+        ones = 0;
+        tens = 0;
+ 
+        tens_model RotateRoll( step, 0.05 );
+        ones_model RotateRoll( step, 0.05 );
+ 
+        for ( ;; )
+        {
+            wait( 1 );
+ 
+			for ( ;; )
+			{
+				num_players = level.players.size;
+				dial = ones + ( tens * 10 );
+ 
+			if ( num_players < dial )
+			{
+					ones--;
+					time = 0.5;
+                if ( ones < 0 )
+                {
+					ones = 9;
+					tens_model RotateRoll( 0 - step, time );
+					tens--;
+                }
+ 
+				ones_model RotateRoll( 0 - step, time );
+				ones_model waittill( "rotatedone" );
+			}
+			else if ( num_players > dial )
+			{
+				ones++;
+				time = 0.5;
+ 
+                if ( ones > 9 )
+                {
+					ones = 0;
+					tens_model RotateRoll( step, time );
+					tens++;
+				}
+ 
+				ones_model RotateRoll( step, time );
+				ones_model waittill( "rotatedone" );
+			}
+			else
+			{
+				break;
+			}
+		}
+	}
+}
+       
+nuked_doomsday_clock_init()
+{
+	min_hand_model = GetEnt( "clock_min_hand", "targetname" );
+	sec_hand_model = GetEnt( "clock_sec_hand", "targetname" );
+	start_angle = 318;
+	min_hand_model RotatePitch( start_angle, 0.05 );
+	min_hand_model waittill( "rotatedone" );
+   
+	if ( level.timelimit > 0 )
+	{
+		min_hand_model RotatePitch( 360 - start_angle, level.timelimit * 60 );
+		sec_hand_model RotatePitch( 360 * level.timelimit, level.timelimit * 60 );
+	}
+	else
+	{
+		sec_hand_model thread nuked_doomsday_clock_seconds_think();
+	}
+}
+ 
+nuked_doomsday_clock_seconds_think()
+{
+	for ( ;; )
+	{
+		self RotatePitch( 360, 60 );
+		self waittill( "rotatedone" );
+	}
+}

--- a/maps/mp/mp_overgrown.gsc
+++ b/maps/mp/mp_overgrown.gsc
@@ -1,1 +1,21 @@
-main(){maps\mp\mp_overgrown_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_overgrown_dlc");game["attackers"]="axis";game["defenders"]="allies";SetDvar("r_specularcolorscale","1");SetDvar("compassmaxrange","2200");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.0);setdvar("r_lightGridContrast",1);}
+main()
+{
+	maps\mp\mp_overgrown_precache::main();
+	//maps\mp\mp_overgrown_fx::main();
+	maps\createart\mp_overgrown_art::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_overgrown_dlc" );
+
+	//AmbientPlay( "ambient_mp_overgrown" );
+
+	game["attackers"] = "axis";
+	game["defenders"] = "allies";
+
+	SetDvar( "r_specularcolorscale", "1" );
+	SetDvar( "compassmaxrange", "2200" );
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.0 );
+	setdvar( "r_lightGridContrast", 1 );
+}

--- a/maps/mp/mp_quarry.gsc
+++ b/maps/mp/mp_quarry.gsc
@@ -1,1 +1,26 @@
-main(){maps\mp\mp_quarry_precache::main();maps\mp\_load::main();maps\mp\_explosive_barrels::main();maps\mp\_compass::setupMiniMap("compass_map_mp_quarry");setdvar("compassmaxrange","2800");VisionSetNaked("mp_quarry");level.airstrikeHeightScale=2;game["attackers"]="allies";game["defenders"]="axis";setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.22);setdvar("r_lightGridContrast",.67);}
+main()
+{
+	maps\mp\mp_quarry_precache::main();
+	//maps\mp\mp_quarry_fx::main();
+	maps\createart\mp_quarry_art::main();
+	maps\mp\_load::main();
+	maps\mp\_explosive_barrels::main();
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_quarry" );
+	setdvar( "compassmaxrange", "2800" );
+
+	//setExpFog( 900, 3500, 0.631373, 0.568627, 0.54902, 1, 0 );
+	//setExpFog( 900, 3500, 0.631373, 0.568627, 0.34902, 1, 0, 1, 0.803922, 0.564706, (0, .5, 1), 0, 	15.2331, 0.961894 );
+	
+	//ambientPlay( "ambient_mp_desert" );
+	VisionSetNaked( "mp_quarry" );
+
+	// raise up planes to avoid them flying through buildings
+	level.airstrikeHeightScale = 2;
+
+	game[ "attackers" ] = "axis";
+	game[ "defenders" ] = "allies";
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.22 );
+	setdvar( "r_lightGridContrast", .67 );
+}

--- a/maps/mp/mp_rundown.gsc
+++ b/maps/mp/mp_rundown.gsc
@@ -1,1 +1,24 @@
-main(){maps\mp\mp_rundown_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_rundown");VisionSetNaked("mp_rundown");game["attackers"]="axis";game["defenders"]="allies";setdvar("r_specularcolorscale","1.67");setdvar("compassmaxrange","3000");setdvar("sm_sunShadowScale","0.5");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.16);setdvar("r_lightGridContrast",1);}
+main()
+{
+	maps\mp\mp_rundown_precache::main();
+	//maps\mp\mp_rundown_fx::main();
+	maps\createart\mp_rundown_art::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_rundown" );
+
+	//setExpFog( 1695, 5200, 0.8, 0.8, 0.8, 0.2, 0 );
+	//ambientPlay( "ambient_mp_rural" );
+	VisionSetNaked( "mp_rundown" );
+
+	game[ "attackers" ] = "axis";
+	game[ "defenders" ] = "allies";
+
+	setdvar( "r_specularcolorscale", "1.67" );
+	setdvar( "compassmaxrange", "3000" );
+	setdvar( "sm_sunShadowScale", "0.5" ); // optimization
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.16 );
+	setdvar( "r_lightGridContrast", 1 );
+}

--- a/maps/mp/mp_rust.gsc
+++ b/maps/mp/mp_rust.gsc
@@ -1,1 +1,19 @@
-main(){maps\mp\mp_rust_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_rust");setdvar("compassmaxrange","1400");game["attackers"]="allies";game["defenders"]="axis";}
+
+main()
+{
+
+	maps\mp\mp_rust_precache::main();
+	maps\createart\mp_rust_art::main();
+	//maps\mp\mp_rust_fx::main();
+
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_rust" );
+
+	setdvar( "compassmaxrange", "1400" );
+
+	//ambientPlay( "ambient_mp_duststorm" );
+
+	game[ "attackers" ] = "allies";
+	game[ "defenders" ] = "axis";
+}

--- a/maps/mp/mp_rust_long.gsc
+++ b/maps/mp/mp_rust_long.gsc
@@ -1,0 +1,23 @@
+#include maps\mp\_utility;
+
+main()
+{
+
+	maps\mp\mp_rust_long_precache::main();
+	maps\createart\mp_rust_long_art::main();
+	maps\createfx\mp_rust_long_fx::main();
+	//maps\mp\mp_rust_long_fx::main();
+
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_rust_long" );
+
+	setdvar( "compassmaxrange", "1400" );
+
+	//ambientPlay( "ambient_mp_duststorm" );
+
+	game[ "attackers" ] = "allies";
+	game[ "defenders" ] = "axis";
+	
+	setdvar( "r_diffusecolorscale", "1.4" );
+}

--- a/maps/mp/mp_shipment.gsc
+++ b/maps/mp/mp_shipment.gsc
@@ -1,0 +1,165 @@
+main()
+{
+	//maps\mp\mp_shipment_fx::main();
+	maps\createart\mp_shipment_art::main();
+	maps\createfx\mp_shipment_fx::main();
+	maps\mp\_load::main();
+	
+	maps\mp\_compass::setupMiniMap("compass_map_mp_shipment");
+	
+	//ambientPlay("ambient_trainer_ext2"); //TODO: get proper ambient
+
+	game["attackers"] = "axis";
+	game["defenders"] = "allies";
+
+	setdvar( "r_specularcolorscale", "1.7" );
+	setdvar( "r_diffusecolorscale", "1.3" );
+
+	setdvar("compassmaxrange","1400");
+	
+	level thread deleteChaModels();
+}
+
+deleteChaModels()
+{	
+	count = 0;
+	count2 = 0;
+	count3 = 0;
+	globalIntermission = getEntArray ( "mp_global_intermission", "targetname" );
+	dmSpawns = getEntArray ( "mp_dm_spawn", "targetname" );
+	domSpawns = getEntArray ( "mp_dom_spawn", "targetname" );
+	tdmSpawns = getEntArray ( "mp_tdm_spawn", "targetname" );
+
+	// ---- DEFINING GAMETYPE OBJECTS ----
+	
+	universalExploderAB = getEntArray ( "exploder", "targetname" );
+	
+	// - CTF -
+	flagRemoveAllies = getEntArray ( "ctf_flag_allies", "targetname" );
+	flagTrigRemoveAllies = getEntArray ( "ctf_trig_allies", "targetname" );
+	flagZoneRemoveAllies = getEntArray ( "ctf_zone_allies", "targetname" );
+	flagRemoveAxis = getEntArray ( "ctf_flag_axis", "targetname" );
+	flagTrigRemoveAxis = getEntArray ( "ctf_trig_axis", "targetname" );
+	flagZoneRemoveAxis = getEntArray ( "ctf_zone_axis", "targetname" );
+	
+	// - DD -
+	ddbombzonesTouchAB = getEntArray ( "dd_bombzone", "targetname" );
+	ddbombzonesModelA = getEntArray ( "pf408_auto1", "targetname" ) ;
+	ddbombzonesTrigA = getEntArray ( "pf408_auto2", "targetname" );
+	ddbombzonesModelB = getEntArray ( "pf409_auto1", "targetname" ) ;
+	ddbombzonesTrigB = getEntArray ( "pf409_auto2", "targetname" );
+	ddbombzonesCollA = getEntArray ( "dd_bombzone_clip_a", "targetname" );
+	ddbombzonesCollB = getEntArray ( "dd_bombzone_clip_b", "targetname" );
+	
+	// - Dom -
+	flagPrimary = getEntArray ( "flag_primary", "targetname" );
+	flagDescriptor = getEntArray ("flag_descriptor", "targetname" );
+	
+	// - Sab -
+	sabbombzonesColl = getEntArray ( "sab_bomb_col", "targetname" );
+	sabbombzonesTouchAllies = getEntArray ( "sab_bomb_allies", "targetname" );
+	sabbombzonesDefuseAllies = getEntArray ( "sab_bomb_defuse_allies", "targetname" );
+	sabbombzonesSiteModelAllies = getEntArray ( "pf397_auto1", "targetname" );
+	sabbombzonesTouchAxis = getEntArray ( "sab_bomb_axis", "targetname" );
+	sabbombzonesDefuseAxis = getEntArray ( "sab_bomb_defuse_axis", "targetname" );
+	sabbombzonesSiteModelAxis = getEntArray ( "pf398_auto1", "targetname" );
+	
+	// - SnD -
+	bombzonesTouchAB = getEntArray ( "bombzone", "targetname" );
+	bombzonesCollAB = getEntArray ( "bomb_col", "targetname" );
+	bombzonesModelA = getEntArray ( "pf393_auto1", "targetname" );
+	bombzonesTrigA = getEntArray ( "pf393_auto2", "targetname" );
+	bombzonesModelB = getEntArray ( "pf394_auto1", "targetname" );
+	bombzonesTrigB = getEntArray ( "pf394_auto2", "targetname" );
+	bombzonesBrief = getEntArray ( "sd_bomb", "targetname" );
+	bombzonesBriefTrig = getEntArray ( "sd_bomb_pickup_trig", "targetname" );
+	
+	// ---- DELETING GAMETYPE OBJECTS ----
+	
+	foreach( ent in dmSpawns )
+	{
+		count2++;
+		if (count2 > 7)
+		{
+			dmSpawns[count2] Delete();
+		}
+	}
+	
+	flagRemoveAllies[0] Delete();
+	flagTrigRemoveAllies[0] Delete();
+	flagZoneRemoveAllies[0] Delete();
+	flagRemoveAxis[0] Delete();
+	flagTrigRemoveAxis[0] Delete();
+	flagZoneRemoveAxis[0] Delete();
+	foreach( ent in domSpawns )
+	{
+		count++;
+		if (count > 7)
+		{
+			domSpawns[count] Delete();
+		}
+	}
+	
+	ddbombzonesTouchAB[0] Delete();
+	ddbombzonesTouchAB[1] Delete();
+	ddbombzonesModelA[0] Delete();
+	ddbombzonesTrigA[0] Delete();
+	ddbombzonesModelB[0] Delete();
+	ddbombzonesTrigB[0] Delete();
+	universalExploderAB[8] Delete();
+	universalExploderAB[9] Delete();
+	ddbombzonesCollA[0] Delete();
+	ddbombzonesCollB[0] Delete();
+	
+	flagPrimary[0] Delete();
+	flagPrimary[1] Delete();
+	flagPrimary[2] Delete();
+	flagDescriptor[0] Delete();
+	flagDescriptor[1] Delete();
+	flagDescriptor[2] Delete();
+	
+	sabbombzonesColl[0] Delete();
+	sabbombzonesColl[1] Delete();
+	sabbombzonesTouchAllies[0] Delete();
+	sabbombzonesDefuseAllies[0] Delete();
+	sabbombzonesSiteModelAllies[0] Delete();
+	sabbombzonesTouchAxis[0] Delete();
+	sabbombzonesDefuseAxis[0] Delete();
+	sabbombzonesSiteModelAxis[0] Delete();
+	universalExploderAB[4] Delete();
+	universalExploderAB[5] Delete();
+	
+	bombzonesTouchAB[0] Delete();
+	bombzonesTouchAB[1] Delete();
+	universalExploderAB[0] Delete();
+	universalExploderAB[1] Delete();
+	bombzonesCollAB[0] Delete();
+	bombzonesCollAB[1] Delete();
+	bombzonesModelA[0] Delete();
+	bombzonesModelB[0] Delete();
+	bombzonesTrigA[0] Delete();
+	bombzonesTrigB[0] Delete();
+	bombzonesBrief[0] Delete();
+	bombzonesBriefTrig[0] Delete();
+	
+	foreach( ent in tdmSpawns )
+	{
+		count3++;
+		if (count3 > 7)
+		{
+			tdmSpawns[count3] Delete();
+		}
+	}
+	
+	
+	// - Removing the barrels -
+	
+	chaRemove = getEntArray ( "cha", "targetname" );
+	
+	foreach( ent in chaRemove )
+	{
+		ent Delete();
+	}
+	
+	globalIntermission[0] Delete();
+}

--- a/maps/mp/mp_shipment_long.gsc
+++ b/maps/mp/mp_shipment_long.gsc
@@ -1,0 +1,157 @@
+main()
+{
+	//maps\mp\mp_shipment_long_fx::main();
+	maps\createart\mp_shipment_long_art::main();
+	maps\createfx\mp_shipment_long_fx::main();
+	maps\mp\_load::main();
+	
+	maps\mp\_compass::setupMiniMap("compass_map_mp_shipment");
+	
+	//ambientPlay("ambient_mp_rain");
+
+	game["attackers"] = "axis";
+	game["defenders"] = "allies";
+
+	setdvar( "r_specularcolorscale", "1" );
+	setdvar( "r_diffusecolorscale", "0.8" );
+
+	setdvar("compassmaxrange", "1400");
+	
+	//Too lazy to set up Head Quarters!
+	if ( getDvar( "g_gametype" ) != "koth" )
+		level thread deleteChaModels();
+	else
+		level thread deleteBarrels();
+}
+
+deleteChaModels()
+{	
+	maps\mp\_compass::setupMiniMap("compass_map_mp_shipment_long");
+	globalIntermission = getEntArray ( "mp_global_intermission", "targetname" );
+	dmSpawns = getEntArray ( "mp_dm_spawn", "targetname" );
+	domSpawns = getEntArray ( "mp_dom_spawn", "targetname" );
+	tdmSpawns = getEntArray ( "mp_tdm_spawn", "targetname" );
+
+	// ---- DEFINING GAMETYPE OBJECTS ----
+	
+	universalExploderAB = getEntArray ( "exploder", "targetname" );
+	
+	// - CTF -
+	flagRemoveAllies = getEntArray ( "ctf_flag_allies", "targetname" );
+	flagTrigRemoveAllies = getEntArray ( "ctf_trig_allies", "targetname" );
+	flagZoneRemoveAllies = getEntArray ( "ctf_zone_allies", "targetname" );
+	flagRemoveAxis = getEntArray ( "ctf_flag_axis", "targetname" );
+	flagTrigRemoveAxis = getEntArray ( "ctf_trig_axis", "targetname" );
+	flagZoneRemoveAxis = getEntArray ( "ctf_zone_axis", "targetname" );
+	
+	// - DD -
+	ddbombzonesTouchAB = getEntArray ( "dd_bombzone", "targetname" );
+	ddbombzonesModelA = getEntArray ( "pf408_auto1", "targetname" ) ;
+	ddbombzonesTrigA = getEntArray ( "pf408_auto2", "targetname" );
+	ddbombzonesModelB = getEntArray ( "pf409_auto1", "targetname" ) ;
+	ddbombzonesTrigB = getEntArray ( "pf409_auto2", "targetname" );
+	ddbombzonesCollA = getEntArray ( "dd_bombzone_clip_a", "targetname" );
+	ddbombzonesCollB = getEntArray ( "dd_bombzone_clip_b", "targetname" );
+	
+	// - Dom -
+	flagPrimary = getEntArray ( "flag_primary", "targetname" );
+	flagDescriptor = getEntArray ("flag_descriptor", "targetname" );
+	
+	// - Sab -
+	sabbombzonesColl = getEntArray ( "sab_bomb_col", "targetname" );
+	sabbombzonesTouchAllies = getEntArray ( "sab_bomb_allies", "targetname" );
+	sabbombzonesDefuseAllies = getEntArray ( "sab_bomb_defuse_allies", "targetname" );
+	sabbombzonesSiteModelAllies = getEntArray ( "pf397_auto1", "targetname" );
+	sabbombzonesTouchAxis = getEntArray ( "sab_bomb_axis", "targetname" );
+	sabbombzonesDefuseAxis = getEntArray ( "sab_bomb_defuse_axis", "targetname" );
+	sabbombzonesSiteModelAxis = getEntArray ( "pf398_auto1", "targetname" );
+	
+	// - SnD -
+	bombzonesTouchAB = getEntArray ( "bombzone", "targetname" );
+	bombzonesCollAB = getEntArray ( "bomb_col", "targetname" );
+	bombzonesModelA = getEntArray ( "pf393_auto1", "targetname" );
+	bombzonesTrigA = getEntArray ( "pf393_auto2", "targetname" );
+	bombzonesModelB = getEntArray ( "pf394_auto1", "targetname" );
+	bombzonesTrigB = getEntArray ( "pf394_auto2", "targetname" );
+	bombzonesBrief = getEntArray ( "sd_bomb", "targetname" );
+	bombzonesBriefTrig = getEntArray ( "sd_bomb_pickup_trig", "targetname" );
+	
+	dmSpawns[6] Delete();
+	dmSpawns[7] Delete();
+	
+	flagRemoveAllies[1] Delete();
+	flagTrigRemoveAllies[1] Delete();
+	flagZoneRemoveAllies[1] Delete();
+	flagRemoveAxis[1] Delete();
+	flagTrigRemoveAxis[1] Delete();
+	flagZoneRemoveAxis[1] Delete();
+	
+	ddbombzonesTouchAB[2] Delete();
+	ddbombzonesTouchAB[3] Delete();
+	ddbombzonesModelA[1] Delete();
+	ddbombzonesTrigA[1] Delete();
+	ddbombzonesModelB[1] Delete();
+	ddbombzonesTrigB[1] Delete();
+	universalExploderAB[10] Delete();
+	universalExploderAB[11] Delete();
+	ddbombzonesCollA[1] Delete();
+	ddbombzonesCollB[1] Delete();
+	
+	flagPrimary[3] Delete();
+	flagPrimary[4] Delete();
+	flagPrimary[5] Delete();
+	flagDescriptor[3] Delete();
+	flagDescriptor[4] Delete();
+	flagDescriptor[5] Delete();
+	domSpawns[4] Delete();
+	domSpawns[5] Delete();
+	
+	sabbombzonesColl[2] Delete();
+	sabbombzonesColl[3] Delete();
+	sabbombzonesTouchAllies[1] Delete();
+	sabbombzonesDefuseAllies[1] Delete();
+	sabbombzonesSiteModelAllies[1] Delete();
+	sabbombzonesTouchAxis[1] Delete();
+	sabbombzonesDefuseAxis[1] Delete();
+	sabbombzonesSiteModelAxis[1] Delete();
+	universalExploderAB[6] Delete();
+	universalExploderAB[7] Delete();
+	
+	bombzonesTouchAB[2] Delete();
+	bombzonesTouchAB[3] Delete();
+	universalExploderAB[2] Delete();
+	universalExploderAB[3] Delete();
+	bombzonesCollAB[2] Delete();
+	bombzonesCollAB[3] Delete();
+	bombzonesModelA[1] Delete();
+	bombzonesModelB[1] Delete();
+	bombzonesTrigA[1] Delete();
+	bombzonesTrigB[1] Delete();
+	bombzonesBrief[1] Delete();
+	bombzonesBriefTrig[1] Delete();
+	
+	tdmSpawns[4] Delete();
+	tdmSpawns[5] Delete();
+	
+	chargeRemove = getEntArray ( "charge_remove", "targetname" );
+	
+	foreach( ent in chargeRemove )
+	{
+		ent Delete();
+	}
+		
+	globalIntermission[1] Delete();
+}
+
+deleteBarrels()
+{	
+	globalIntermission = getEntArray ( "mp_global_intermission", "targetname" );
+	chaRemove = getEntArray ( "cha", "targetname" );
+	
+	foreach( ent in chaRemove )
+	{
+		ent Delete();
+	}
+	
+	globalIntermission[0] Delete();
+}

--- a/maps/mp/mp_storm.gsc
+++ b/maps/mp/mp_storm.gsc
@@ -1,1 +1,20 @@
-main(){maps\mp\mp_storm_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_storm");game["attackers"]="axis";game["defenders"]="allies";setdvar("r_specularcolorscale","1.5");setdvar("compassmaxrange","2300");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.3);}
+main()
+{
+	maps\mp\mp_storm_precache::main();
+	//maps\mp\mp_storm_fx::main();
+	maps\createart\mp_storm_art::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_storm" );
+
+	//ambientPlay( "ambient_mp_storm" );
+
+	game[ "attackers" ] = "axis";
+	game[ "defenders" ] = "allies";
+
+	setdvar( "r_specularcolorscale", "1.5" );
+	setdvar( "compassmaxrange", "2300" );
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.3 );
+	//setdvar( "r_lightGridContrast", .5 );
+}

--- a/maps/mp/mp_storm_spring.gsc
+++ b/maps/mp/mp_storm_spring.gsc
@@ -1,0 +1,20 @@
+main()
+{
+	maps\mp\mp_storm_spring_precache::main();
+	//maps\mp\mp_storm_spring_fx::main();
+	maps\createart\mp_storm_spring_art::main();
+	maps\createfx\mp_storm_spring_fx::main();
+	maps\createfx\mp_storm_spring_ex_fx::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_storm_spring" );
+
+	//ambientPlay( "ambient_mp_snow" );
+
+	game[ "attackers" ] = "axis";
+	game[ "defenders" ] = "allies";
+
+	setdvar( "r_specularcolorscale", "2" );
+	setdvar( "r_diffusecolorscale", "1.2" );
+	setdvar( "compassmaxrange", "2300" );
+}

--- a/maps/mp/mp_strike.gsc
+++ b/maps/mp/mp_strike.gsc
@@ -1,1 +1,27 @@
-main(){maps\mp\mp_strike_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_strike");game["attackers"]="allies";game["defenders"]="axis";SetDvar("compassmaxrange","1900");SetDvar("r_specularcolorscale","1.86");thread BreakGlass();}BreakGlass(){glass=GetGlassArray("brokenglass01");foreach(piece in glass)DestroyGlass(piece);}
+main()
+{
+	maps\mp\mp_strike_precache::main();
+	//maps\mp\mp_strike_fx::main();
+	maps\createart\mp_strike_art::main();
+	maps\mp\_load::main();
+	
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_strike" );
+
+	//AmbientPlay( "ambient_mp_strike" );
+
+	game["attackers"] = "allies";
+	game["defenders"] = "axis";
+
+	SetDvar( "compassmaxrange", "1900" );
+	SetDvar( "r_specularcolorscale", "1.86" );
+	
+	thread BreakGlass();
+}
+
+BreakGlass()
+{
+	glass = GetGlassArray( "brokenglass01" );
+	
+	foreach( piece in glass )
+		DestroyGlass( piece );
+}

--- a/maps/mp/mp_subbase.gsc
+++ b/maps/mp/mp_subbase.gsc
@@ -1,1 +1,21 @@
-main(){maps\mp\mp_subbase_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_subbase");game["defenders"]="axis";game["attackers"]="allies";setdvar("r_specularcolorscale","2.9");setdvar("compassmaxrange","2500");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",2);}
+main()
+{
+	maps\mp\mp_subbase_precache::main();
+	maps\createart\mp_subbase_art::main();
+	//maps\mp\mp_subbase_fx::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_subbase" );
+
+	//ambientPlay( "ambient_mp_snow" );
+
+	game[ "defenders"] = "axis";
+	game[ "attackers"] = "allies";
+
+
+	setdvar( "r_specularcolorscale", "2.9" );
+	setdvar( "compassmaxrange", "2500" );
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 2 );
+	//setdvar( "r_lightGridContrast", 0 );
+}

--- a/maps/mp/mp_terminal.gsc
+++ b/maps/mp/mp_terminal.gsc
@@ -1,1 +1,23 @@
-main(){maps\mp\mp_terminal_precache::main();maps\mp\_explosive_barrels::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_terminal");setdvar("compassmaxrange","2000");VisionSetNaked("mp_terminal");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.22);setdvar("r_lightGridContrast",.6);game["attackers"]="allies";game["defenders"]="axis";}
+
+main()
+{
+	maps\mp\mp_terminal_precache::main();
+	maps\createart\mp_terminal_art::main();
+	//maps\mp\mp_terminal_fx::main();
+	maps\mp\_explosive_barrels::main();
+	maps\mp\_load::main();
+	
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_terminal" );
+	setdvar( "compassmaxrange", "2000" );
+	
+	//ambientPlay( "ambient_mp_airport" );
+	
+	VisionSetNaked( "mp_terminal" );
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.22 );
+	setdvar( "r_lightGridContrast", .6 );
+	
+	game["attackers"] = "allies";
+	game["defenders"] = "axis";
+}

--- a/maps/mp/mp_trailerpark.gsc
+++ b/maps/mp/mp_trailerpark.gsc
@@ -1,1 +1,26 @@
-main(){maps\mp\mp_trailerpark_precache::main();maps\mp\_destructible_dlc2::main();maps\mp\_destructible_dlc::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_trailerpark");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.33);setdvar("compassmaxrange","1700");game["attackers"]="allies";game["defenders"]="axis";}
+
+main()
+{
+	maps\mp\mp_trailerpark_precache::main();
+	maps\createart\mp_trailerpark_art::main();
+	//maps\mp\mp_trailerpark_fx::main();
+
+	maps\mp\_destructible_dlc2::main(); // call before _load
+	maps\mp\_destructible_dlc::main(); // call before _load
+
+	maps\mp\_load::main();
+	
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_trailerpark" );
+	
+	
+	setdvar( "r_lightGridEnableTweaks", 1 );
+//	setdvar( "r_specularcolorscale", "1.7" );
+	setdvar( "r_lightGridIntensity", 1.33 );
+	
+	setdvar( "compassmaxrange", "1700" );
+	
+	//AmbientPlay( "ambient_mp_trailerpark" );
+	
+	game["attackers"] = "allies";
+	game["defenders"] = "axis";
+}

--- a/maps/mp/mp_underpass.gsc
+++ b/maps/mp/mp_underpass.gsc
@@ -1,1 +1,25 @@
-main(){maps\mp\mp_underpass_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_underpass");setdvar("compassmaxrange","2800");game["attackers"]="allies";game["defenders"]="axis";setdvar("r_specularcolorscale","3.1");setdvar("r_diffusecolorscale",".78");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.3);setdvar("r_lightGridContrast",.5);}
+main()
+{
+	maps\mp\mp_underpass_precache::main();
+	maps\createart\mp_underpass_art::main();
+	//maps\mp\mp_underpass_fx::main();
+	maps\mp\_load::main();
+
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_underpass" );
+	setdvar( "compassmaxrange", "2800" );
+
+	//setExpFog( 500, 3500, .5, 0.5, 0.45, 1, 0 );
+	//ambientPlay( "ambient_mp_rain" );
+
+	game[ "attackers" ] = "axis";
+	game[ "defenders" ] = "allies";
+	
+	setdvar( "r_specularcolorscale", "3.1" );
+	setdvar( "r_diffusecolorscale", ".78" );
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.3 );
+	setdvar( "r_lightGridContrast", .5 );
+
+	if ( level.ps3 )
+		setdvar( "sm_sunShadowScale", "0.5" ); // ps3 optimization
+}

--- a/maps/mp/mp_vacant.gsc
+++ b/maps/mp/mp_vacant.gsc
@@ -1,1 +1,21 @@
-main(){maps\mp\mp_vacant_precache::main();maps\mp\_load::main();maps\mp\_compass::setupMiniMap("compass_map_mp_vacant_dlc");game["attackers"]="axis";game["defenders"]="allies";SetDvar("r_specularcolorscale","1");SetDvar("compassmaxrange","1500");setdvar("r_lightGridEnableTweaks",1);setdvar("r_lightGridIntensity",1.0);setdvar("r_lightGridContrast",1);}
+main()
+{
+	maps\mp\mp_vacant_precache::main();
+	//maps\mp\mp_vacant_fx::main();
+	maps\createart\mp_vacant_art::main();
+	maps\mp\_load::main();
+	
+	maps\mp\_compass::setupMiniMap( "compass_map_mp_vacant_dlc" );
+	
+	//AmbientPlay( "ambient_mp_vacant" );
+	
+	game["attackers"] = "axis";
+	game["defenders"] = "allies";
+
+	SetDvar( "r_specularcolorscale", "1" );
+	SetDvar( "compassmaxrange", "1500" );
+		
+	setdvar( "r_lightGridEnableTweaks", 1 );
+	setdvar( "r_lightGridIntensity", 1.0 );
+	setdvar( "r_lightGridContrast", 1 );
+}


### PR DESCRIPTION
This commit properly formats gsc files for each map under `maps/mp`.

It also removes ambient noises and weather effects from these maps:

- Bloc
- Bog
- Chemical Plant
- Crash Tropical
- Estate Tropical
- Freighter
- Firing Range
- Rust Long
- Shipment
- Shipment Long