### PR TITLE
bring unnecessary includes back

### DIFF
--- a/maps/createfx/co_hunted_fx.gsc
+++ b/maps/createfx/co_hunted_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/contingency_fx.gsc
+++ b/maps/createfx/contingency_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/gulag_fx.gsc
+++ b/maps/createfx/gulag_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/invasion_fx.gsc
+++ b/maps/createfx/invasion_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_abandon_fx.gsc
+++ b/maps/createfx/mp_abandon_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_afghan_fx.gsc
+++ b/maps/createfx/mp_afghan_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_bloc_fx.gsc
+++ b/maps/createfx/mp_bloc_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_bloc_sh_fx.gsc
+++ b/maps/createfx/mp_bloc_sh_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_bog_sh_fx.gsc
+++ b/maps/createfx/mp_bog_sh_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_boneyard_fx.gsc
+++ b/maps/createfx/mp_boneyard_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_brecourt_fx.gsc
+++ b/maps/createfx/mp_brecourt_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_cargoship_fx.gsc
+++ b/maps/createfx/mp_cargoship_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_cargoship_sh_fx.gsc
+++ b/maps/createfx/mp_cargoship_sh_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_checkpoint_fx.gsc
+++ b/maps/createfx/mp_checkpoint_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_compact_fx.gsc
+++ b/maps/createfx/mp_compact_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_complex_fx.gsc
+++ b/maps/createfx/mp_complex_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_crash_fx.gsc
+++ b/maps/createfx/mp_crash_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_crash_trop_fx.gsc
+++ b/maps/createfx/mp_crash_trop_fx.gsc
@@ -1,2 +1,0 @@
-//_createfx generated. Do not touch!!
-main(){}

--- a/maps/createfx/mp_crash_tropical_fx.gsc
+++ b/maps/createfx/mp_crash_tropical_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_cross_fire_fx.gsc
+++ b/maps/createfx/mp_cross_fire_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_derail_fx.gsc
+++ b/maps/createfx/mp_derail_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_estate_fx.gsc
+++ b/maps/createfx/mp_estate_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_estate_tropical_fx.gsc
+++ b/maps/createfx/mp_estate_tropical_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_fav_tropical_fx.gsc
+++ b/maps/createfx/mp_fav_tropical_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_favela_fx.gsc
+++ b/maps/createfx/mp_favela_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_firingrange_fx.gsc
+++ b/maps/createfx/mp_firingrange_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_fuel2_fx.gsc
+++ b/maps/createfx/mp_fuel2_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_highrise_fx.gsc
+++ b/maps/createfx/mp_highrise_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_invasion_fx.gsc
+++ b/maps/createfx/mp_invasion_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_killhouse_fx.gsc
+++ b/maps/createfx/mp_killhouse_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_nightshift_fx.gsc
+++ b/maps/createfx/mp_nightshift_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_nuked_fx.gsc
+++ b/maps/createfx/mp_nuked_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_overgrown_fx.gsc
+++ b/maps/createfx/mp_overgrown_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_quarry_fx.gsc
+++ b/maps/createfx/mp_quarry_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_rundown_fx.gsc
+++ b/maps/createfx/mp_rundown_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_rust_fx.gsc
+++ b/maps/createfx/mp_rust_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_rust_long_fx.gsc
+++ b/maps/createfx/mp_rust_long_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_shipment_fx.gsc
+++ b/maps/createfx/mp_shipment_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_shipment_long_fx.gsc
+++ b/maps/createfx/mp_shipment_long_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_storm_fx.gsc
+++ b/maps/createfx/mp_storm_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_storm_spring_fx.gsc
+++ b/maps/createfx/mp_storm_spring_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_strike_fx.gsc
+++ b/maps/createfx/mp_strike_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_subbase_fx.gsc
+++ b/maps/createfx/mp_subbase_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_terminal_fx.gsc
+++ b/maps/createfx/mp_terminal_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_trailerpark_fx.gsc
+++ b/maps/createfx/mp_trailerpark_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_underpass_fx.gsc
+++ b/maps/createfx/mp_underpass_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/mp_vacant_fx.gsc
+++ b/maps/createfx/mp_vacant_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/oilrig_fx.gsc
+++ b/maps/createfx/oilrig_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}

--- a/maps/createfx/so_ghillies_fx.gsc
+++ b/maps/createfx/so_ghillies_fx.gsc
@@ -1,2 +1,4 @@
 //_createfx generated. Do not touch!!
+#include common_scripts\utility;
+#include common_scripts\_createfx;
 main(){}


### PR DESCRIPTION
My previous changes to fx files causes some errors in game.
Example: `Error: Unexpected text 'main(){ }' when trying to find '#include common_scripts\utility' in map's effect file`

This pull request reverts my [previous pull request](https://github.com/ChxseH/IW4x-Promod/pull/6) to fix these error messages.

It also deletes `mp_crash_trop_fx.gsc` since this file is not used. Correct file name is `mp_crash_tropical_fx.gsc`